### PR TITLE
Stride support

### DIFF
--- a/include/puma.h
+++ b/include/puma.h
@@ -160,7 +160,7 @@ class ConvolutionalConstantMatrix {
 
     public:
 
-        static ConvolutionalConstantMatrix create(Model model, std::string name, unsigned int kernelWidth, unsigned kernelHeight, unsigned int nInChannels, unsigned int nOutChannels);
+        static ConvolutionalConstantMatrix create(Model model, std::string name, unsigned int kernelWidth, unsigned kernelHeight, unsigned int nInChannels, unsigned int nOutChannels, unsigned int stride, unsigned int out_size_x, unsigned int out_size_y);
 
         ConvolutionalConstantMatrixImpl* unwrap();
 

--- a/src/common.h
+++ b/src/common.h
@@ -13,8 +13,8 @@
 
 /* Constants */
 #define MVMU_DIM                        128
-#define N_CONSTANT_MVMUS_PER_CORE       6
-#define N_TRAINING_MVMUS_PER_CORE       2
+#define N_CONSTANT_MVMUS_PER_CORE       2
+#define N_TRAINING_MVMUS_PER_CORE       0
 #define N_CORES_PER_TILE                8
 #define MAX_LOAD_STORE_WIDTH            16
 #define MAX_SEND_RECV_WIDTH             16

--- a/src/tensors.cpp
+++ b/src/tensors.cpp
@@ -43,9 +43,9 @@ ConstantMatrix ConstantMatrix::create(Model model, std::string name, unsigned in
     return m;
 }
 
-ConvolutionalConstantMatrix ConvolutionalConstantMatrix::create(Model model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels) {
+ConvolutionalConstantMatrix ConvolutionalConstantMatrix::create(Model model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels, unsigned int stride, unsigned int out_size_x, unsigned int out_size_y) {
     ConvolutionalConstantMatrix m;
-    m.impl_ = new ConvolutionalConstantMatrixImpl(model.unwrap(), name, kernelWidth, kernelHeight, nInChannels, nOutChannels);
+    m.impl_ = new ConvolutionalConstantMatrixImpl(model.unwrap(), name, kernelWidth, kernelHeight, nInChannels, nOutChannels, stride, out_size_x, out_size_y);
     return m;
 }
 
@@ -220,8 +220,8 @@ ConstantMatrixImpl::ConstantMatrixImpl(ModelImpl* model, std::string name, unsig
     model->addConstantMatrixImpl(this);
 }
 
-ConvolutionalConstantMatrixImpl::ConvolutionalConstantMatrixImpl(ModelImpl* model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels)
-    : AbstractTensor(model, name), kernelWidth_(kernelWidth), kernelHeight_(kernelHeight), nInChannels_(nInChannels), nOutChannels_(nOutChannels)
+ConvolutionalConstantMatrixImpl::ConvolutionalConstantMatrixImpl(ModelImpl* model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels, unsigned int stride, unsigned int out_size_x, unsigned int out_size_y)
+    : AbstractTensor(model, name), kernelWidth_(kernelWidth), kernelHeight_(kernelHeight), nInChannels_(nInChannels), nOutChannels_(nOutChannels), stride_(stride), out_size_x_(out_size_x), out_size_y_(out_size_y)
 {
     tiles_.resize(kernelHeight);
     for(unsigned int kh = 0; kh < kernelHeight; ++kh) {

--- a/src/tensors.h
+++ b/src/tensors.h
@@ -331,17 +331,23 @@ class ConvolutionalConstantMatrixImpl : public AbstractTensor {
         unsigned int kernelHeight_;
         unsigned int nInChannels_;
         unsigned int nOutChannels_;
+	unsigned int stride_;
+	unsigned int out_size_x_;
+	unsigned int out_size_y_;
         std::vector< std::vector< std::vector< std::vector<ConstantMatrixTile*> > > > tiles_;
 
     public:
 
-        ConvolutionalConstantMatrixImpl(ModelImpl* model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels);
+        ConvolutionalConstantMatrixImpl(ModelImpl* model, std::string name, unsigned int kernelWidth, unsigned int kernelHeight, unsigned int nInChannels, unsigned int nOutChannels, unsigned int stride, unsigned int out_size_x, unsigned int out_size_y);
         ~ConvolutionalConstantMatrixImpl();
 
         unsigned int getKernelWidth() { return kernelWidth_; }
         unsigned int getKernelHeight() { return kernelHeight_; }
         unsigned int getNInChannels() { return nInChannels_; }
         unsigned int getNOutChannels() { return nOutChannels_; }
+        unsigned int getStride() { return stride_; }
+	unsigned int getOutWidth() {return out_size_x_;}	
+	unsigned int getOutHeight() {return out_size_y_;}
         unsigned int getNInChannelTiles() { return (nInChannels_ - 1)/MVMU_DIM + 1; }
         unsigned int getNOutChannelTiles() { return (nOutChannels_ - 1)/MVMU_DIM + 1; }
         ConstantMatrixTile* getTile(unsigned int kh, unsigned int kw, unsigned int h, unsigned int w);

--- a/test/conv-layer.cpp
+++ b/test/conv-layer.cpp
@@ -9,41 +9,50 @@
 #include <assert.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 #include "puma.h"
 #include "conv-layer.h"
-
+using namespace std;
 int main(int argc, char** argv) {
 
-    Model model = Model::create("conv-layer");
+//    Model model = Model::create("conv3-layer");
 
-    // Process parameters
-    unsigned int in_size_x = 14;
-    unsigned int in_size_y = 14;
-    unsigned int in_channels = 512;
-    unsigned int out_channels = 512;
-    unsigned int k_size_x = 3;
-    unsigned int k_size_y = 3;
-    if(argc == 7) {
+    // Process parameter
+    unsigned int in_size_x ; 
+    unsigned int in_size_y ; 
+    unsigned int in_channels ;
+    unsigned int out_channels ;
+    unsigned int k_size_x ;
+    unsigned int k_size_y ;
+    unsigned int padding ;
+    unsigned int stride ;
+
+    if(argc == 10) {
         in_size_x = atoi(argv[1]);
         in_size_y = atoi(argv[2]);
         in_channels = atoi(argv[3]);
         out_channels = atoi(argv[4]);
         k_size_x = atoi(argv[5]);
         k_size_y = atoi(argv[6]);
-    }
-
+		padding = atoi(argv[7]);
+		stride = atoi(argv[8]);
+    }    
+    std:: string str=std::string("conv") + argv[9] + std::string("-layer");
+    Model model = Model::create(str);
+   
     // Input stream
     auto in_stream = InputImagePixelStream::create(model, "in_stream", in_size_x, in_size_y, in_channels);
 
     // Output stream
-    unsigned int out_size_x = in_size_x;
-    unsigned int out_size_y = in_size_y;
+    unsigned int out_size_x = (in_size_x - k_size_x + 2*padding)/stride + 1;
+    unsigned int out_size_y =  (in_size_y - k_size_y + 2*padding)/stride + 1;
+   
+   	assert((in_size_x - k_size_x + 2*padding)%stride==0); //input image size should result in integer out image size
     auto out_stream = OutputImagePixelStream::create(model, "out_stream", out_size_x, out_size_y, out_channels);
-
+    
     // Layer
-    out_stream = conv_layer(model, "", k_size_x, k_size_y, in_size_x, in_size_y, in_channels, out_channels, in_stream);
-
+    out_stream = conv_layer(model, "", k_size_x, k_size_y, in_size_x, in_size_y, in_channels, out_channels, stride, out_size_x, out_size_y, in_stream);
     // Compile
     model.compile();
 

--- a/test/conv-layer.cpp
+++ b/test/conv-layer.cpp
@@ -13,6 +13,7 @@
 
 #include "puma.h"
 #include "conv-layer.h"
+using namespace std;
 int main(int argc, char** argv) {
 
 //    Model model = Model::create("conv3-layer");
@@ -24,7 +25,7 @@ int main(int argc, char** argv) {
     unsigned int out_channels=16 ;
     unsigned int k_size_x=3 ;
     unsigned int k_size_y=3 ;
-    unsigned int padding=3 ;
+    unsigned int padding=1 ;
     unsigned int stride=1 ;
 
     if(argc == 10) {

--- a/test/conv-layer.cpp
+++ b/test/conv-layer.cpp
@@ -13,20 +13,19 @@
 
 #include "puma.h"
 #include "conv-layer.h"
-using namespace std;
 int main(int argc, char** argv) {
 
 //    Model model = Model::create("conv3-layer");
 
     // Process parameter
-    unsigned int in_size_x ; 
-    unsigned int in_size_y ; 
-    unsigned int in_channels ;
-    unsigned int out_channels ;
-    unsigned int k_size_x ;
-    unsigned int k_size_y ;
-    unsigned int padding ;
-    unsigned int stride ;
+    unsigned int in_size_x=9 ; 
+    unsigned int in_size_y=9 ; 
+    unsigned int in_channels=16 ;
+    unsigned int out_channels=16 ;
+    unsigned int k_size_x=3 ;
+    unsigned int k_size_y=3 ;
+    unsigned int padding=3 ;
+    unsigned int stride=1 ;
 
     if(argc == 10) {
         in_size_x = atoi(argv[1]);

--- a/test/conv-layer.h
+++ b/test/conv-layer.h
@@ -11,17 +11,17 @@
 
 #include "puma.h"
 
-static ImagePixelStream conv_layer(Model model, std::string layerName, unsigned int k_size_x, unsigned int k_size_y, unsigned int in_size_x, unsigned int in_size_y, unsigned int in_channels, unsigned int out_channels, ImagePixelStream in_stream) {
+static ImagePixelStream conv_layer(Model model, std::string layerName, unsigned int k_size_x, unsigned int k_size_y, unsigned int in_size_x, unsigned int in_size_y, unsigned int in_channels, unsigned int out_channels, unsigned int stride, unsigned int out_size_x, unsigned int out_size_y, ImagePixelStream in_stream) {
 
-    ConvolutionalConstantMatrix mat = ConvolutionalConstantMatrix::create(model, layerName + "conv_mat", k_size_x, k_size_y, in_channels, out_channels);
+    ConvolutionalConstantMatrix mat = ConvolutionalConstantMatrix::create(model, layerName + "conv_mat", k_size_x, k_size_y, in_channels, out_channels, stride, out_size_x, out_size_y);
 
     return sig(mat*in_stream);
 
 }
 
-static ImagePixelStream convmax_layer(Model model, std::string layerName, unsigned int k_size_x, unsigned int k_size_y, unsigned int in_size_x, unsigned int in_size_y, unsigned int in_channels, unsigned int out_channels, unsigned int max_pool_size_x, unsigned int max_pool_size_y, ImagePixelStream in_stream) {
+static ImagePixelStream convmax_layer(Model model, std::string layerName, unsigned int k_size_x, unsigned int k_size_y, unsigned int in_size_x, unsigned int in_size_y, unsigned int in_channels, unsigned int out_channels, unsigned int stride, unsigned int out_size_x, unsigned int max_pool_size_x, unsigned int max_pool_size_y, ImagePixelStream in_stream) {
 
-    ConvolutionalConstantMatrix mat = ConvolutionalConstantMatrix::create(model, layerName + "conv_mat", k_size_x, k_size_y, in_channels, out_channels);
+    ConvolutionalConstantMatrix mat = ConvolutionalConstantMatrix::create(model, layerName + "conv_mat", k_size_x, k_size_y, in_channels, out_channels, stride, out_size_x, out_size_x);
 
     return maxpool(sig(mat*in_stream), max_pool_size_y, max_pool_size_x);
 


### PR DESCRIPTION
Stride support for DNNs that use striding to downsample. Use the model files in **puma-simulator/test/cnn/conv-layer-stride.cpp** to use the stride support option. Change the working branch in the compiler to **stride-support**. Also, the scripts to run the PUMA compiler+simulator with striding option is added in **puma-simulator/test/utils/**.  